### PR TITLE
feat: add installation order page layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,6 @@
+// app.js
+App({
+  globalData: {
+    version: '1.0.0'
+  }
+});

--- a/app.json
+++ b/app.json
@@ -1,0 +1,11 @@
+{
+  "pages": [
+    "pages/install/install"
+  ],
+  "window": {
+    "navigationBarTitleText": "安装单",
+    "navigationBarBackgroundColor": "#ffffff",
+    "navigationBarTextStyle": "black",
+    "backgroundColor": "#f5f5f5"
+  }
+}

--- a/app.wxss
+++ b/app.wxss
@@ -1,0 +1,17 @@
+/** app.wxss **/
+page {
+  background-color: #f5f6f8;
+  font-family: 'PingFang SC', 'Helvetica Neue', Arial, sans-serif;
+}
+
+.container {
+  padding: 20rpx 24rpx 40rpx;
+  box-sizing: border-box;
+}
+
+.section-title {
+  font-size: 30rpx;
+  color: #333;
+  font-weight: 600;
+  margin: 24rpx 0;
+}

--- a/pages/install/install.js
+++ b/pages/install/install.js
@@ -1,0 +1,69 @@
+Page({
+  data: {
+    activeTab: 'pending',
+    tabs: [
+      { id: 'pending', label: '未回访' },
+      { id: 'finished', label: '已回访' }
+    ],
+    searchValue: '',
+    pendingList: [
+      {
+        cardNo: 'EINS9234567',
+        userName: 'cba',
+        address: '北京市市辖区海淀区街道54333',
+        phone: '133****0503',
+        installDate: '2025-10-18'
+      },
+      {
+        cardNo: 'EINS711112',
+        userName: '张三',
+        address: '北京市昌南藏族自治区州临泽县1231号',
+        phone: '134****0503',
+        installDate: '2025-10-19'
+      },
+      {
+        cardNo: 'EINS250908',
+        userName: '张三丰',
+        address: '陕西省西安市长安区兴国路实验全3号',
+        phone: '133****0503',
+        installDate: '2025-12-13'
+      }
+    ],
+    finishedList: [
+      {
+        cardNo: 'EINS1234001',
+        userName: '李雷',
+        address: '北京市东城区新中街100号',
+        phone: '138****0503',
+        installDate: '2025-06-01'
+      },
+      {
+        cardNo: 'EINS1234568',
+        userName: '韩梅梅',
+        address: '天津市和平区南京路20号',
+        phone: '139****0503',
+        installDate: '2025-06-12'
+      }
+    ]
+  },
+
+  onSearchInput(e) {
+    this.setData({ searchValue: e.detail.value });
+  },
+
+  clearSearch() {
+    this.setData({ searchValue: '' });
+  },
+
+  switchTab(e) {
+    const { id } = e.currentTarget.dataset;
+    this.setData({ activeTab: id });
+  },
+
+  handleCreate() {
+    wx.showToast({
+      title: '点击新增',
+      icon: 'none'
+    });
+  }
+});

--- a/pages/install/install.json
+++ b/pages/install/install.json
@@ -1,0 +1,4 @@
+{
+  "navigationBarTitleText": "安装单",
+  "usingComponents": {}
+}

--- a/pages/install/install.wxml
+++ b/pages/install/install.wxml
@@ -1,0 +1,71 @@
+<view class="page">
+  <view class="toolbar">
+    <icon type="home" size="24" color="#333" />
+    <view class="toolbar-actions">
+      <icon type="search" size="24" color="#333" />
+      <icon type="more" size="24" color="#333" />
+    </view>
+  </view>
+
+  <view class="tabs">
+    <block wx:for="{{tabs}}" wx:key="id">
+      <view
+        class="tab-item {{activeTab === item.id ? 'active' : ''}}"
+        data-id="{{item.id}}"
+        bindtap="switchTab"
+      >
+        {{item.label}}
+      </view>
+    </block>
+  </view>
+
+  <view class="search-box">
+    <icon type="search" size="18" color="#888" />
+    <input
+      class="search-input"
+      value="{{searchValue}}"
+      placeholder="请输入报修卡号或用户电话"
+      placeholder-class="search-placeholder"
+      bindinput="onSearchInput"
+    />
+    <icon
+      wx:if="{{searchValue}}"
+      type="clear"
+      size="18"
+      color="#bbb"
+      bindtap="clearSearch"
+    />
+  </view>
+
+  <view class="create-card" bindtap="handleCreate">
+    <text class="plus">＋</text>
+    <text>新增</text>
+  </view>
+
+  <view class="list">
+    <block wx:for="{{activeTab === 'pending' ? pendingList : finishedList}}" wx:key="cardNo">
+      <view class="card">
+        <view class="card-row">
+          <text class="label">报修卡号</text>
+          <text class="value">{{item.cardNo}}</text>
+        </view>
+        <view class="card-row">
+          <text class="label">用户姓名</text>
+          <text class="value">{{item.userName}}</text>
+        </view>
+        <view class="card-row">
+          <text class="label">用户地址</text>
+          <text class="value address">{{item.address}}</text>
+        </view>
+        <view class="card-row">
+          <text class="label">用户电话</text>
+          <text class="value">{{item.phone}}</text>
+        </view>
+        <view class="card-row">
+          <text class="label">安装日期</text>
+          <text class="value">{{item.installDate}}</text>
+        </view>
+      </view>
+    </block>
+  </view>
+</view>

--- a/pages/install/install.wxss
+++ b/pages/install/install.wxss
@@ -1,0 +1,131 @@
+.page {
+  min-height: 100vh;
+  padding: 32rpx 24rpx 48rpx;
+  box-sizing: border-box;
+  background: #f5f6f8;
+}
+
+.toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-bottom: 24rpx;
+}
+
+.toolbar icon {
+  margin-right: 16rpx;
+}
+
+.toolbar-actions icon:last-child {
+  margin-right: 0;
+}
+
+.tabs {
+  display: flex;
+  justify-content: space-around;
+  padding: 10rpx;
+  background-color: #fff;
+  border-radius: 999rpx;
+  box-shadow: 0 8rpx 20rpx rgba(0, 0, 0, 0.04);
+  margin-bottom: 32rpx;
+}
+
+.tab-item {
+  flex: 1;
+  text-align: center;
+  font-size: 28rpx;
+  color: #777;
+  padding: 18rpx 0;
+  border-radius: 999rpx;
+  transition: all 0.2s;
+}
+
+.tab-item.active {
+  font-weight: 600;
+  color: #111;
+  background: linear-gradient(90deg, #eef2ff, #f0f8ff);
+  box-shadow: 0 8rpx 16rpx rgba(33, 114, 255, 0.12);
+}
+
+.search-box {
+  display: flex;
+  align-items: center;
+  padding: 18rpx 24rpx;
+  background-color: #fff;
+  border-radius: 16rpx;
+  box-shadow: 0 8rpx 24rpx rgba(0, 0, 0, 0.05);
+  margin-bottom: 24rpx;
+}
+
+.search-input {
+  flex: 1;
+  margin: 0 18rpx;
+  font-size: 26rpx;
+  color: #333;
+}
+
+.search-placeholder {
+  color: #aaa;
+}
+
+.create-card {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16rpx;
+  padding: 24rpx;
+  margin-bottom: 32rpx;
+  background: #fff;
+  border-radius: 16rpx;
+  border: 2rpx dashed #d0e4ff;
+  color: #1f6fff;
+  font-size: 28rpx;
+  box-shadow: 0 8rpx 24rpx rgba(31, 111, 255, 0.12);
+}
+
+.create-card .plus {
+  font-size: 36rpx;
+  font-weight: 600;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 24rpx;
+}
+
+.card {
+  background-color: #fff;
+  border-radius: 20rpx;
+  padding: 28rpx;
+  box-shadow: 0 12rpx 28rpx rgba(31, 111, 255, 0.08);
+}
+
+.card-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 20rpx;
+}
+
+.card-row:last-child {
+  margin-bottom: 0;
+}
+
+.label {
+  width: 160rpx;
+  font-size: 26rpx;
+  color: #555;
+}
+
+.value {
+  flex: 1;
+  text-align: right;
+  font-size: 28rpx;
+  color: #222;
+}
+
+.value.address {
+  line-height: 1.6;
+  text-align: left;
+}


### PR DESCRIPTION
## Summary
- scaffold a WeChat Mini Program with a single installation order page
- implement tabbed visit states, search box, and sample installation cards
- style the screen to match the provided installation order mockup

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d409fc91f883309e0b8659891b0505