### PR TITLE
feat: add parts application overview page

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,7 @@
 {
   "pages": [
-    "pages/install/install"
+    "pages/install/install",
+    "pages/partsList/partsList"
   ],
   "window": {
     "navigationBarTitleText": "安装单",

--- a/pages/partsList/partsList.js
+++ b/pages/partsList/partsList.js
@@ -1,0 +1,152 @@
+Page({
+  data: {
+    searchValue: '',
+    hasEmptyImage: false,
+    tabs: [
+      {
+        id: 'apply',
+        label: '部品调品申请',
+        tip: '跟进在途申请',
+        gradient: 'linear-gradient(135deg, #2b7bff, #54c7ff)',
+        textColor: '#ffffff'
+      },
+      {
+        id: 'return',
+        label: '部品调品退还',
+        tip: '查看退还进度',
+        gradient: 'linear-gradient(135deg, #f7b500, #ffd56f)',
+        textColor: '#2d2000'
+      }
+    ],
+    activeTab: 'apply',
+    applyList: [
+      {
+        orderNo: 'ESQ20250910-00014',
+        company: '秦皇岛房博商贸有限公司',
+        partsCount: 1,
+        productCount: 0,
+        statusText: '审批通过',
+        statusType: 'success',
+        actionText: '申请登录',
+        actionType: 'primary',
+        date: '2025-09-10',
+        dateHint: '计划发货'
+      },
+      {
+        orderNo: 'ETH20250910-00012',
+        company: '宁波三盛工业供应链有限公司',
+        partsCount: 2,
+        productCount: 0,
+        statusText: '备货中',
+        statusType: 'waiting',
+        actionText: '申请登录',
+        actionType: 'primary',
+        date: '2025-09-10',
+        dateHint: '预计到货'
+      },
+      {
+        orderNo: 'ESQ20250828-00001',
+        company: '上海捷顺服务外包有限公司',
+        partsCount: 1,
+        productCount: 1,
+        statusText: '待审核',
+        statusType: 'warning',
+        actionText: '申请登录',
+        actionType: 'primary',
+        date: '2025-08-28',
+        dateHint: '刚刚提交'
+      }
+    ],
+    returnList: [
+      {
+        orderNo: 'RET20250910-00003',
+        company: '苏州景鸿售后维修中心',
+        partsCount: 1,
+        productCount: 0,
+        statusText: '待回收',
+        statusType: 'warning',
+        actionText: '退还登录',
+        actionType: 'secondary',
+        date: '2025-09-10',
+        dateHint: '预计入库'
+      },
+      {
+        orderNo: 'RET20250830-00008',
+        company: '广东星河服务保障有限公司',
+        partsCount: 3,
+        productCount: 1,
+        statusText: '已入库',
+        statusType: 'success',
+        actionText: '退还详情',
+        actionType: 'success',
+        date: '2025-08-30',
+        dateHint: '完成退还'
+      }
+    ],
+    filteredList: []
+  },
+
+  onLoad() {
+    this.updateFilteredList();
+  },
+
+  onSwitchTab(event) {
+    const { id } = event.currentTarget.dataset;
+    if (!id || id === this.data.activeTab) {
+      return;
+    }
+
+    this.setData(
+      {
+        activeTab: id
+      },
+      () => {
+        this.updateFilteredList();
+      }
+    );
+  },
+
+  onSearchInput(event) {
+    const value = event.detail.value || '';
+    const filteredList = this.filterList(this.getActiveList(), value);
+
+    this.setData({
+      searchValue: value,
+      filteredList
+    });
+  },
+
+  clearSearch() {
+    const filteredList = this.getActiveList();
+    this.setData({
+      searchValue: '',
+      filteredList
+    });
+  },
+
+  getActiveList() {
+    const { activeTab, applyList, returnList } = this.data;
+    return activeTab === 'apply' ? applyList : returnList;
+  },
+
+  filterList(list, keyword) {
+    const rawKeyword = (keyword || '').trim();
+    const value = rawKeyword.toLowerCase();
+    if (!value) {
+      return list;
+    }
+
+    return list.filter((item) => {
+      const orderNo = (item.orderNo || '').toLowerCase();
+      const company = item.company || '';
+      return orderNo.indexOf(value) > -1 || company.indexOf(rawKeyword) > -1;
+    });
+  },
+
+  updateFilteredList() {
+    const filteredList = this.filterList(this.getActiveList(), this.data.searchValue);
+    this.setData({
+      filteredList
+    });
+  }
+});

--- a/pages/partsList/partsList.json
+++ b/pages/partsList/partsList.json
@@ -1,0 +1,3 @@
+{
+  "navigationBarTitleText": "部品申请一览"
+}

--- a/pages/partsList/partsList.wxml
+++ b/pages/partsList/partsList.wxml
@@ -1,0 +1,90 @@
+<view class="page">
+  <view class="header">
+    <view class="search-area">
+      <view class="search-box">
+        <icon type="search" size="18" color="#7a8ba5" />
+        <input
+          class="search-input"
+          value="{{searchValue}}"
+          placeholder="请输入申请单编号"
+          placeholder-class="search-placeholder"
+          confirm-type="search"
+          bindinput="onSearchInput"
+        />
+        <icon
+          wx:if="{{searchValue}}"
+          type="clear"
+          size="18"
+          color="#b6c0d2"
+          bindtap="clearSearch"
+        />
+      </view>
+      <view class="actions">
+        <view class="action-item action-item--primary">
+          <text>≡</text>
+        </view>
+        <view class="action-item">
+          <text>⋯</text>
+        </view>
+      </view>
+    </view>
+
+    <view class="tab-bar">
+      <block wx:for="{{tabs}}" wx:key="id">
+        <view
+          class="tab {{activeTab === item.id ? 'active' : ''}}"
+          data-id="{{item.id}}"
+          style="{{activeTab === item.id ? 'background:' + item.gradient + ';color:' + item.textColor : ''}}"
+          bindtap="onSwitchTab"
+        >
+          <view class="tab-top">
+            <text class="tab-label">{{item.label}}</text>
+            <text class="tab-count">{{item.id === 'apply' ? applyList.length : returnList.length}}</text>
+          </view>
+          <text class="tab-tip">{{item.tip}}</text>
+        </view>
+      </block>
+    </view>
+  </view>
+
+  <view class="list" wx:if="{{filteredList.length}}">
+    <block wx:for="{{filteredList}}" wx:key="orderNo">
+      <view class="card">
+        <view class="card-header">
+          <text class="order-no">{{item.orderNo}}</text>
+          <view class="date-box">
+            <text class="date-value">{{item.date}}</text>
+            <text class="date-hint">{{item.dateHint}}</text>
+          </view>
+        </view>
+
+        <text class="company">{{item.company}}</text>
+
+        <view class="meta">
+          <view class="meta-item">
+            <text class="meta-label">部品</text>
+            <text class="meta-value">{{item.partsCount}} 件</text>
+          </view>
+          <view class="meta-divider"></view>
+          <view class="meta-item">
+            <text class="meta-label">制品</text>
+            <text class="meta-value">{{item.productCount}} 件</text>
+          </view>
+        </view>
+
+        <view class="card-footer">
+          <view class="status-badge status-{{item.statusType}}">{{item.statusText}}</view>
+          <view class="link-button link-{{item.actionType}}">{{item.actionText}}</view>
+        </view>
+      </view>
+    </block>
+  </view>
+
+  <view class="empty" wx:else>
+    <image class="empty-illustration" src="/assets/empty.png" mode="aspectFit" wx:if="{{hasEmptyImage}}" />
+    <view class="empty-card">
+      <text class="empty-title">暂无符合条件的申请单</text>
+      <text class="empty-desc">尝试调整搜索词或切换申请类型</text>
+    </view>
+  </view>
+</view>

--- a/pages/partsList/partsList.wxss
+++ b/pages/partsList/partsList.wxss
@@ -1,0 +1,273 @@
+.page {
+  min-height: 100vh;
+  padding: 48rpx 32rpx 64rpx;
+  box-sizing: border-box;
+  background: linear-gradient(155deg, #f5f7ff 0%, #f9fbff 50%, #fff7f0 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 32rpx;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 32rpx;
+}
+
+.search-area {
+  display: flex;
+  gap: 24rpx;
+  align-items: center;
+}
+
+.search-box {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  padding: 18rpx 24rpx;
+  background: rgba(255, 255, 255, 0.94);
+  border-radius: 22rpx;
+  box-shadow: 0 16rpx 32rpx rgba(45, 115, 255, 0.1);
+}
+
+.search-input {
+  flex: 1;
+  margin: 0 18rpx;
+  font-size: 26rpx;
+  color: #203154;
+}
+
+.search-placeholder {
+  color: #9aa8c1;
+}
+
+.actions {
+  display: flex;
+  gap: 16rpx;
+}
+
+.action-item {
+  width: 72rpx;
+  height: 72rpx;
+  border-radius: 24rpx;
+  background: rgba(255, 255, 255, 0.92);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #60708d;
+  font-size: 36rpx;
+  box-shadow: 0 16rpx 30rpx rgba(45, 115, 255, 0.12);
+}
+
+.action-item--primary {
+  background: linear-gradient(135deg, rgba(43, 123, 255, 0.12), rgba(100, 176, 255, 0.25));
+  color: #2b7bff;
+}
+
+.tab-bar {
+  display: flex;
+  gap: 24rpx;
+}
+
+.tab {
+  flex: 1;
+  padding: 26rpx 30rpx;
+  border-radius: 26rpx;
+  background: rgba(255, 255, 255, 0.86);
+  box-shadow: inset 0 0 0 1rpx rgba(255, 255, 255, 0.5);
+  display: flex;
+  flex-direction: column;
+  gap: 12rpx;
+  color: #4b5d7d;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tab.active {
+  transform: translateY(-4rpx);
+  box-shadow: 0 18rpx 32rpx rgba(43, 123, 255, 0.18);
+}
+
+.tab-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.tab-label {
+  font-size: 28rpx;
+  font-weight: 600;
+}
+
+.tab-count {
+  padding: 4rpx 16rpx;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 999rpx;
+  font-size: 22rpx;
+}
+
+.tab-tip {
+  font-size: 24rpx;
+  opacity: 0.82;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 24rpx;
+}
+
+.card {
+  padding: 28rpx 32rpx;
+  border-radius: 28rpx;
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: 0 18rpx 36rpx rgba(45, 115, 255, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 20rpx;
+}
+
+.card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24rpx;
+}
+
+.order-no {
+  font-size: 30rpx;
+  font-weight: 700;
+  color: #1c2f60;
+}
+
+.date-box {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6rpx;
+  color: #2b7bff;
+}
+
+.date-value {
+  font-size: 28rpx;
+  font-weight: 600;
+}
+
+.date-hint {
+  font-size: 22rpx;
+  opacity: 0.75;
+}
+
+.company {
+  font-size: 26rpx;
+  color: #3a4b6f;
+  line-height: 1.4;
+}
+
+.meta {
+  display: flex;
+  align-items: center;
+  gap: 24rpx;
+  color: #566789;
+}
+
+.meta-item {
+  display: flex;
+  align-items: baseline;
+  gap: 12rpx;
+}
+
+.meta-label {
+  font-size: 24rpx;
+  opacity: 0.7;
+}
+
+.meta-value {
+  font-size: 26rpx;
+  font-weight: 600;
+}
+
+.meta-divider {
+  width: 2rpx;
+  height: 32rpx;
+  background: rgba(33, 114, 255, 0.18);
+}
+
+.card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.status-badge {
+  padding: 8rpx 20rpx;
+  border-radius: 999rpx;
+  font-size: 24rpx;
+  font-weight: 600;
+}
+
+.status-success {
+  background: rgba(46, 204, 113, 0.16);
+  color: #1e9156;
+}
+
+.status-warning {
+  background: rgba(255, 193, 7, 0.18);
+  color: #b06b00;
+}
+
+.status-waiting {
+  background: rgba(45, 115, 255, 0.12);
+  color: #2b7bff;
+}
+
+.link-button {
+  font-size: 26rpx;
+  font-weight: 600;
+}
+
+.link-primary {
+  color: #2b7bff;
+}
+
+.link-secondary {
+  color: #f39c12;
+}
+
+.link-success {
+  color: #1e9156;
+}
+
+.empty {
+  margin-top: 80rpx;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24rpx;
+}
+
+.empty-illustration {
+  width: 360rpx;
+  height: 240rpx;
+}
+
+.empty-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 28rpx;
+  padding: 36rpx 40rpx;
+  box-shadow: 0 16rpx 30rpx rgba(54, 107, 255, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 12rpx;
+  text-align: center;
+}
+
+.empty-title {
+  font-size: 28rpx;
+  font-weight: 600;
+  color: #1c2f60;
+}
+
+.empty-desc {
+  font-size: 24rpx;
+  color: #5e6f90;
+}


### PR DESCRIPTION
## Summary
- add a dedicated "部品申请一览" page with styling aligned to the existing UI theme
- implement static sample data with tab switching and inline filtering support
- register the new page within the mini-program configuration

## Testing
- not run (mini program project)


------
https://chatgpt.com/codex/tasks/task_e_68d425a7e2b08330b2d54e11905c595e